### PR TITLE
Added the phase-based frequency masking technique and an example script.

### DIFF
--- a/examples/demo_pfm.py
+++ b/examples/demo_pfm.py
@@ -1,0 +1,62 @@
+import argparse as ap
+import numpy as np
+
+import kissdsp.beamformer as bf
+import kissdsp.filterbank as fb
+import kissdsp.io as io
+import kissdsp.micarray as ma
+import kissdsp.reverb as rb
+import kissdsp.spatial as sp
+import kissdsp.visualize as vz
+
+# Parse arguments
+parser = ap.ArgumentParser(description='Plot wave forms.')
+parser.add_argument('--wave', type=str, default='')
+args = parser.parse_args()
+
+# Create a rectangular room with two sources
+rm = rb.room(mics=np.asarray([[-0.05, -0.05, +0.00], [-0.05, +0.05, +0.00], [+0.05, -0.05, +0.00], [+0.05, +0.05, +0.00]]),
+             box=np.asarray([10.0, 10.0, 2.5]),
+             srcs=np.asarray([[2.0, 3.0, 1.0], [8.0, 7.0, 1.5]]),
+             origin=np.asarray([4.0, 5.0, 1.25]),
+             alphas=0.8 * np.ones(6),
+             c=343.0)
+
+# Create room impulse responses
+hy = rb.rir(rm)
+ht = hy[[0], :, :]
+hr = hy[[1], :, :]
+
+# Load first channel from speech audio
+t = io.read(args.wave)[[0], :]
+
+# Generate white noise
+r = 0.01 * np.random.normal(size=t.shape)
+
+# Combine input sources
+y = np.concatenate([t,r], axis=0)
+
+# Apply room impulse response
+ts = rb.conv(ht, t)
+ys = rb.conv(hy, y)
+
+# Compute spectrograms
+Ts = fb.stft(ts)
+Ys = fb.stft(ys)
+
+# Compute spatial correlation matrices
+TTs = sp.scm(sp.xspec(Ts))
+
+# Compute steering vector
+ws = sp.steering(TTs)
+
+# Perform phase-based frequency masking
+Zs = bf.pfm(Ys, ws)
+
+# Return to time domain
+zs = fb.istft(Zs)
+
+vz.spex(Ys)
+vz.spex(Zs)
+vz.wave(ys)
+vz.wave(zs)


### PR DESCRIPTION
The added technique resides in the function kissdsp.beamformer.pfm, which can be optionally fed with the phase difference threshold (in degrees; 10 seems to work well, but should be tuned per application scenario). The functions returns both the SOI estimation, as well as the noise estimation.