### PR TITLE
Added some functionality to calculate the steering vector using TDOAs…

### DIFF
--- a/examples/demo_pfm-mvdr.py
+++ b/examples/demo_pfm-mvdr.py
@@ -1,0 +1,112 @@
+import argparse as ap
+import numpy as np
+
+import kissdsp.beamformer as bf
+import kissdsp.filterbank as fb
+import kissdsp.io as io
+import kissdsp.micarray as ma
+import kissdsp.reverb as rb
+import kissdsp.spatial as sp
+import kissdsp.visualize as vz
+
+# Parse arguments
+parser = ap.ArgumentParser(description='Plot wave forms.')
+parser.add_argument('--wave', type=str, default='')
+args = parser.parse_args()
+
+# Create a rectangular room with two sources
+rm = rb.room(mics=np.asarray([[-0.05, -0.05, +0.00], [-0.05, +0.05, +0.00], [+0.05, -0.05, +0.00], [+0.05, +0.05, +0.00]]),
+             box=np.asarray([10.0, 10.0, 2.5]),
+             srcs=np.asarray([[2.0, 3.0, 1.0], [8.0, 7.0, 1.5]]),
+             origin=np.asarray([4.0, 5.0, 1.25]),
+             alphas=0.8 * np.ones(6),
+             c=343.0)
+
+# Get number of channels
+n_channels = rm["mics"].shape[0]
+
+# Create room impulse responses
+hy = rb.rir(rm)
+ht = hy[[0], :, :]
+hr = hy[[1], :, :]
+
+# Load first channel from speech audio
+t = io.read(args.wave)[[0], :]
+
+# Generate white noise
+r = 0.01 * np.random.normal(size=t.shape)
+
+# Combine input sources
+y = np.concatenate([t,r], axis=0)
+
+# Apply room impulse response
+ts = rb.conv(ht, t)
+rs = rb.conv(hr, r)
+ys = rb.conv(hy, y)
+
+# Compute spectrograms
+Ts = fb.stft(ts)
+Rs = fb.stft(rs)
+Ys = fb.stft(ys)
+
+# Compute time-difference-of-arrival of target speech
+tdoas = rb.tdoa(rm)
+tdoa_t = tdoas[0,:]
+
+# Compute oracle spatial correlation matrices
+TTs = sp.scm(sp.xspec(Ts))
+RRs = sp.scm(sp.xspec(Rs))
+
+# Compute steering vectors, using oracle spatial correlation, as well as tdoas
+ws_mvdr_target = bf.mvdr(TTs, RRs)
+ws_mvdr_interf = bf.mvdr(RRs, TTs)
+ws_tdoa = sp.steering_tdoa(tdoa_t)
+
+# Perform MVDR as reference
+Zs_mvdr_target = bf.beam(Ys, ws_mvdr_target)
+Zs_mvdr_interf = bf.beam(Ys, ws_mvdr_interf)
+
+# Perform phase-based frequency masking as reference
+Zs_tdoa = bf.pfm(Ys, ws_tdoa)
+
+# use phase-based frequency masking to create a mask
+Zs_mask = bf.pfm(Ys, ws_tdoa, return_mask=True)
+
+# create masked versions of the input using phase-based frequency masks
+target_mask = np.tile(Zs_mask[0,:,:],(n_channels,1,1))
+interf_mask = np.tile(Zs_mask[1,:,:],(n_channels,1,1))
+Ys_masked_target = Ys * target_mask
+Ys_masked_interf = Ys * interf_mask
+
+# use masked input to create spatial correlation matrices
+TTs_mask = sp.diagload(sp.scm(sp.xspec(Ys_masked_target)))
+RRs_mask = sp.diagload(sp.scm(sp.xspec(Ys_masked_interf)))
+
+# Perform MVDR with "masked" correlation matrices
+ws_mvdr_mask_target = bf.mvdr(TTs_mask, RRs_mask)
+ws_mvdr_mask_interf = bf.mvdr(RRs_mask, TTs_mask)
+Zs_mask_target = bf.beam(Ys, ws_mvdr_mask_target)
+Zs_mask_interf = bf.beam(Ys, ws_mvdr_mask_interf)
+
+# Return to time domain
+zs_mvdr_target = fb.istft(Zs_mvdr_target)
+zs_mvdr_interf = fb.istft(Zs_mvdr_interf)
+zs_mask_target = fb.istft(Zs_mask_target)
+zs_mask_interf = fb.istft(Zs_mask_interf)
+zs_tdoa = fb.istft(Zs_tdoa)
+
+#vz.spex(Ys)
+#vz.spex(np.concatenate((Zs_mvdr_target,Zs_mask_target),axis=0))
+#vz.spex(np.concatenate((Zs_mvdr_interf,Zs_mask_interf),axis=0))
+#vz.wave(ys)
+#vz.wave(np.concatenate((zs_mvdr_target,zs_mask_target),axis=0))
+#vz.wave(np.concatenate((zs_mvdr_interf,zs_mask_interf),axis=0))
+
+io.write(ys[[0],:]*20,"mic.wav")
+io.write(zs_mvdr_target*20,"mvdr_target.wav")
+io.write(zs_mvdr_interf*20,"mvdr_interf.wav")
+io.write(zs_mask_target*20,"mask_target.wav")
+io.write(zs_mask_interf*20,"mask_interf.wav")
+io.write(zs_tdoa[[0],:]*20,"pfm_target.wav")
+io.write(zs_tdoa[[1],:]*20,"pfm_interf.wav")
+

--- a/examples/demo_pfm.py
+++ b/examples/demo_pfm.py
@@ -44,19 +44,29 @@ ys = rb.conv(hy, y)
 Ts = fb.stft(ts)
 Ys = fb.stft(ys)
 
-# Compute spatial correlation matrices
+# Compute time-difference-of-arrival of target speech
+tdoas = rb.tdoa(rm)
+tdoa_t = tdoas[0,:]
+
+# Compute oracle spatial correlation matrices
 TTs = sp.scm(sp.xspec(Ts))
 
-# Compute steering vector
-ws = sp.steering(TTs)
+# Compute steering vectors, one using spatial correlation, another using tdoas
+ws_scm = sp.steering(TTs)
+ws_tdoa = sp.steering_tdoa(tdoa_t)
 
-# Perform phase-based frequency masking
-Zs = bf.pfm(Ys, ws)
+# Perform phase-based frequency masking using both steering vectors
+Zs_scm = bf.pfm(Ys, ws_scm)
+Zs_tdoa = bf.pfm(Ys, ws_tdoa)
 
 # Return to time domain
-zs = fb.istft(Zs)
+zs_scm = fb.istft(Zs_scm)
+zs_tdoa = fb.istft(Zs_tdoa)
 
 vz.spex(Ys)
-vz.spex(Zs)
+vz.spex(Zs_scm)
+vz.spex(Zs_tdoa)
 vz.wave(ys)
-vz.wave(zs)
+vz.wave(zs_scm)
+vz.wave(zs_tdoa)
+

--- a/kissdsp/beamformer.py
+++ b/kissdsp/beamformer.py
@@ -56,7 +56,7 @@ def gev(SSs, NNs):
     return ws
 
 
-def pfm(Xs, ws, phase_threshold=10):
+def pfm(Xs, ws, phase_threshold=10, return_mask=False):
     """
     Apply phase-based frequency masking.
 
@@ -94,12 +94,18 @@ def pfm(Xs, ws, phase_threshold=10):
     phase_diffs[phase_diffs > 180] = np.abs(360-phase_diffs[phase_diffs > 180])
     phase_avgdiffs = np.mean(phase_diffs,axis=2)
 
+    #deciding if output is a the generated mask or the actual masked signals
+    if return_mask:
+        Ys = np.ones(Xs[:,:,0].shape)
+        Is = np.ones(Xs[:,:,0].shape)
+    else:
+        Ys = np.copy(Xs[:,:,0])
+        Is = np.copy(Xs[:,:,0])
+
     # masking reference microphone based on phase difference threshold to obtain:
     # - the SOI
-    Ys = np.copy(Xs[:,:,0])
     Ys[phase_avgdiffs > phase_threshold] = 0.0
     # - the noise
-    Is = np.copy(Xs[:,:,0])
     Is[phase_avgdiffs <= phase_threshold] = 0.0
 
     return np.concatenate((np.expand_dims(Ys,axis=0),np.expand_dims(Is,axis=0)),axis=0)

--- a/kissdsp/filterbank.py
+++ b/kissdsp/filterbank.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def stft(xs, hop_size=128, frame_size=512):
+def stft(xs, hop_size=128, frame_size=512, wola=False):
     """
     Perform STFT
 
@@ -22,7 +22,11 @@ def stft(xs, hop_size=128, frame_size=512):
     nb_of_frames = int((nb_of_samples - frame_size + hop_size) / hop_size)
     nb_of_bins = int(frame_size/2+1)
 
-    ws = np.tile(np.hanning(frame_size), (nb_of_channels, 1))
+    if wola:
+      ws = np.tile(np.sqrt(np.hanning(frame_size)), (nb_of_channels, 1))
+    else:
+      ws = np.tile(np.hanning(frame_size), (nb_of_channels, 1))
+
     Xs = np.zeros((nb_of_channels, nb_of_frames, nb_of_bins), dtype=np.csingle)
 
     for i in range(0, nb_of_frames):
@@ -31,7 +35,7 @@ def stft(xs, hop_size=128, frame_size=512):
     return Xs
 
 
-def istft(Xs, hop_size=128):
+def istft(Xs, hop_size=128, wola=False):
     """
     Perform iSTFT
 
@@ -51,7 +55,11 @@ def istft(Xs, hop_size=128):
     frame_size = (nb_of_bins-1)*2
     nb_of_samples = nb_of_frames * hop_size + frame_size - hop_size
 
-    ws = np.tile(np.hanning(frame_size), (nb_of_channels, 1))
+    if wola:
+      ws = np.tile(np.sqrt(np.hanning(frame_size)), (nb_of_channels, 1))
+    else:
+      ws = np.tile(np.hanning(frame_size), (nb_of_channels, 1))
+
     xs = np.zeros((nb_of_channels, nb_of_samples), dtype=np.float32)
 
     for i in range(0, nb_of_frames):

--- a/kissdsp/reverb.py
+++ b/kissdsp/reverb.py
@@ -268,7 +268,7 @@ def tdoa(rm, sample_rate=16000):
 
     for source_index in range(0, nb_of_sources):
         dist = np.sqrt(np.sum((rm["srcs"][source_index, :] - (rm["origin"] + rm["mics"])) ** 2, axis=1))
-        tdoas[source_index, :] = (sample_rate/rm["c"]) * dist
+        tdoas[source_index, :] = dist/rm["c"] #(sample_rate/rm["c"]) * dist
         tdoas[source_index, :] -= tdoas[source_index, 0]
 
     return tdoas

--- a/kissdsp/spatial.py
+++ b/kissdsp/spatial.py
@@ -126,6 +126,33 @@ def steering(Cs):
     return vs
 
 
+def steering_tdoa(tdoa, frame_size=512, sample_rate=16000):
+    """
+    Compute the Steering Vector by time-difference-of-arrival
+
+    Args:
+        tdoa (np.ndarray):
+            The time-difference-of-arrival for steered source (1, nb_of_channels)
+        freq_vec (np.ndarray):
+            Frequency value in Hertz for each frequency bin (1, nb_of_bins)
+
+    Returns:
+        (np.ndarray):
+            The steering vector in the frequency domain (nb_of_bins, nb_of_channels)
+    """
+
+    nb_of_bins = int(frame_size/2+1)
+    nb_of_channels = tdoa.shape[0]
+
+    freq_vec = np.arange(nb_of_bins)/(nb_of_bins-1)*(sample_rate/2)
+
+    vs = np.zeros((nb_of_bins,nb_of_channels),dtype = 'complex_')
+    for bin_i in range(nb_of_bins):
+        vs[bin_i,:] = np.exp(1j * -2 * np.pi * freq_vec[bin_i] * tdoa)
+
+    return vs
+
+
 def freefield(tdoas, frame_size=512):
     """
     Generate the Free Field Spatial Correlation Matrix (rank 1)


### PR DESCRIPTION
… instead of SCM. Added to the PFM example script a comparison of both methods. Fixed in reverb.py the calculation of TDOA in seconds, instead of samples.